### PR TITLE
Prevent unnecessary updates of CodeMirror contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Nessie
 [![GitHub package version](https://img.shields.io/github/package-json/v/sociomantic-tsunami/nessie.svg?style=plastic)]()
-[![David](https://img.shields.io/david/sociomantic-tsunami/nessie.svg?style=plastic)]()
-[![David](https://img.shields.io/david/dev/sociomantic-tsunami/nessie.svg?style=plastic)]()
 [![Nessie build status](https://travis-ci.org/sociomantic-tsunami/nessie.svg)](https://travis-ci.org)
 
 React + CSS-Modules + Loads of tests = Robust components for monstrous UIs!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nessie-ui",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Nessie React Components",
   "main": "dist",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "karma-sinon-chai": "^1.2.3",
     "karma-sourcemap-loader": "^0.3.5",
     "karma-webpack": "^2.0.4",
-    "loch-ness": "^1.1.2",
+    "loch-ness": "^2.0.1",
     "lolex": "^1.4.0",
     "markdown-loader": "^2.0.0",
     "microbejs": "^0.5.0",

--- a/src/CodeEditor/index.jsx
+++ b/src/CodeEditor/index.jsx
@@ -181,7 +181,7 @@ export default class CodeEditor extends Component
         Object.keys( combinedOptions ).forEach( option =>
             codeMirror.setOption( option, combinedOptions[ option ] ) );
 
-        if ( typeof value !== 'undefined' )
+        if ( typeof value !== 'undefined' && codeMirror.getValue() !== value )
         {
             codeMirror.setValue( value || '' );
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2156,7 +2156,7 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
-classnames@^2.2.3, classnames@^2.2.4, classnames@^2.2.5:
+classnames@^2.2.4:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -2234,7 +2234,7 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-codemirror@^5.13.4, codemirror@^5.18.2, codemirror@^5.26.0:
+codemirror@^5.26.0:
   version "5.26.0"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.26.0.tgz#bcbee86816ed123870c260461c2b5c40b68746e5"
 
@@ -5911,9 +5911,9 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-"lochness@git+ssh://git@github.com/sociomantic-tsunami/lochness.git#1.1.1":
-  version "1.1.1"
-  resolved "git+ssh://git@github.com/sociomantic-tsunami/lochness.git#4ac37c483cea5b509d5e2fc5da9aa7dea680f0ce"
+loch-ness@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/loch-ness/-/loch-ness-2.0.1.tgz#482f4be74b3fb281642de5aba45835f2763f72e2"
   dependencies:
     autoprefixer "^6.3.3"
     babel-cli "^6.24.1"
@@ -5942,7 +5942,7 @@ locate-path@^2.0.0:
     json-loader "^0.5.4"
     karma-notification-reporter "^0.1.1"
     markdown-loader "^0.1.7"
-    nessie "git+ssh://git@github.com/sociomantic-tsunami/nessie.git#4.0.7"
+    nessie-ui "^5.0.1"
     normalize.css "^5.0.0"
     null-loader "^0.1.1"
     open "^0.0.5"
@@ -5955,7 +5955,6 @@ locate-path@^2.0.0:
     prop-types "^15.5.10"
     raw-loader "^0.5.1"
     react "^15.4.1"
-    react-codemirror "^0.2.6"
     react-copy-to-clipboard "^4.1.0"
     react-dev-server "^0.6.2"
     react-docgen "^2.17.0"
@@ -6062,10 +6061,6 @@ lodash.debounce@^3.0.1:
   dependencies:
     lodash._getnative "^3.0.0"
 
-lodash.debounce@^4.0.4, lodash.debounce@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
-
 lodash.deburr@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash.deburr/-/lodash.deburr-3.2.0.tgz#6da8f54334a366a7cf4c4c76ef8d80aa1b365ed5"
@@ -6095,10 +6090,6 @@ lodash.isarguments@^3.0.0:
 lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
-
-lodash.isequal@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
 lodash.keys@^3.0.0:
   version "3.1.2"
@@ -6623,14 +6614,13 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
-"nessie@git+ssh://git@github.com/sociomantic-tsunami/nessie.git#4.0.7":
-  version "4.0.7"
-  resolved "git+ssh://git@github.com/sociomantic-tsunami/nessie.git#8522e2cc7ab533b018b207ca00a5d0797fefa48b"
+nessie-ui@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/nessie-ui/-/nessie-ui-5.0.1.tgz#21a394cbae8925dc78813cd40ea51c668e07e622"
   dependencies:
     codemirror "^5.26.0"
     copyfiles "^1.2.0"
     lodash.clonedeep "^4.5.0"
-    react-codemirror "^1.0.0"
     rimraf "^2.6.1"
 
 nested-error-stacks@^1.0.0:
@@ -8270,25 +8260,6 @@ react-addons-css-transition-group@~15.6.0:
 react-addons-test-utils@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz#062d36117fe8d18f3ba5e06eb33383b0b85ea5b9"
-
-react-codemirror@^0.2.6:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/react-codemirror/-/react-codemirror-0.2.6.tgz#e71e35717ce6effae68df1dbf2b5a75b84a44f84"
-  dependencies:
-    classnames "^2.2.3"
-    codemirror "^5.13.4"
-    lodash.debounce "^4.0.4"
-
-react-codemirror@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-codemirror/-/react-codemirror-1.0.0.tgz#91467b53b1f5d80d916a2fd0b4c7adb85a9001ba"
-  dependencies:
-    classnames "^2.2.5"
-    codemirror "^5.18.2"
-    create-react-class "^15.5.1"
-    lodash.debounce "^4.0.8"
-    lodash.isequal "^4.5.0"
-    prop-types "^15.5.4"
 
 react-copy-to-clipboard@^4.1.0:
   version "4.3.1"


### PR DESCRIPTION
If the value prop is the same as the current value of the CodeEditor, it doesn't need an update. 

This change prevents this problem:

1. User inputs in CodeEditor component
2. CodeEditor invokes `onChange` with the new value
3. Parent component sets the new value on the CodeEditor `value` prop
4. New value is the same as the current value, but the CodeEditor resets the contents of the CodeMirror instance, and the cursor moves to the first position. 