### PR TITLE
Stop Table props overriding TableRow/TableCell props #136

### DIFF
--- a/src/Table/index.jsx
+++ b/src/Table/index.jsx
@@ -23,9 +23,8 @@ const Table = ( {
     verticalAlign,
 } ) =>
 {
-    const _children = children || buildRowsFromValues( values );
-
-    const rows = React.Children.toArray( _children ).map( row =>
+    const rows = React.Children.toArray( children ||
+        buildRowsFromValues( values ) ).map( row =>
     {
         const cells = React.Children.toArray( row.props.children );
 
@@ -38,8 +37,11 @@ const Table = ( {
                     align       : cell.props.align || column.align,
                     columnTitle : cell.props.columnTitle || column.title,
                     size        : cell.props.size || column.size,
-                    isRowHeader : cell.props.isRowHeader || column.isRowHeader,
-                    isSticky    : cell.props.isSticky || column.isSticky,
+                    isRowHeader : cell.props.isRowHeader ||
+                        column.isRowHeader,
+                    isSticky      : cell.props.isSticky || column.isSticky,
+                    verticalAlign : cell.props.verticalAlign ||
+                        column.verticalAlign,
                 };
 
                 return React.cloneElement( cell, {

--- a/src/Table/index.jsx
+++ b/src/Table/index.jsx
@@ -78,7 +78,7 @@ const Table = ( {
 
         return React.cloneElement( row,
             {
-                align    : align || row.props.align,
+                align    : row.props.align || align,
                 children : cells.map( ( cell, index ) =>
                 {
                     if ( typeof columns[ index ] === 'object' )
@@ -93,19 +93,19 @@ const Table = ( {
                                 className : cell.props.className ?
                                     `${cell.props.className}  ${cssMap.cell}`
                                     : cssMap.cell,
-                                columnTitle : title || cell.props.columnTitle,
-                                size        : size || cell.props.size,
-                                isRowHeader : rowHeaderCell ||
-                                    cell.props.isRowHeader,
-                                isSticky : stickyCell || cell.props.isSticky
+                                columnTitle : cell.props.columnTitle || title,
+                                size        : cell.props.size || size,
+                                isRowHeader : cell.props.isRowHeader ||
+                                    rowHeaderCell,
+                                isSticky : cell.props.isSticky || stickyCell
                             } );
                     }
                     return cell;
                 } ),
                 className : row.props.className ?
                     `${row.props.className}  ${cssMap.row}` : cssMap.row,
-                gutters       : gutters || row.props.gutters,
-                verticalAlign : verticalAlign || row.props.verticalAlign,
+                gutters       : row.props.gutters || gutters ,
+                verticalAlign : row.props.verticalAlign || verticalAlign,
             } );
     } );
 

--- a/src/Table/utils.jsx
+++ b/src/Table/utils.jsx
@@ -1,0 +1,30 @@
+import React     from 'react';
+
+import TableCell from '../TableCell';
+import TableRow  from '../TableRow';
+import Text      from '../Text';
+
+/**
+ * ## buildTableRowsFromValues
+ * Builds TableRows/Cols from a 2D array of string values
+ *
+ * @param   {Array.<Array.<String>>}    values  2D array of values
+ *
+ * @return  {ReactElement}
+ *
+ */
+function buildRowsFromValues( values = [] )
+{
+    return values.map( ( row, i ) => (
+        <TableRow key = { i }>
+            { row.map( ( col, j ) => (
+                <TableCell key = { j }>
+                    <Text>{ col }</Text>
+                </TableCell>
+            ) ) }
+        </TableRow>
+    ) );
+}
+
+export { buildRowsFromValues };
+export default { buildRowsFromValues };

--- a/src/TableCell/index.jsx
+++ b/src/TableCell/index.jsx
@@ -1,10 +1,11 @@
-import React                from 'react';
-import PropTypes            from 'prop-types';
+import React              from 'react';
+import PropTypes          from 'prop-types';
 
-import Css                  from '../hoc/Css';
-import Column               from '../Column';
-import Text                 from '../Text';
-import Sorter               from '../Sorter';
+import Column             from '../Column';
+import Sorter             from '../Sorter';
+import Text               from '../Text';
+import { buildClassName } from '../utils';
+import styles             from './tableCell.css';
 
 const TableCell = ( {
     align,
@@ -34,27 +35,31 @@ const TableCell = ( {
     }
 
     return (
-        <Css
-            cssMap   = { cssMap }
-            cssProps = { {
+        <Column
+            className = { buildClassName( className, cssMap, {
                 header    : isHeader,
                 rowHeader : isRowHeader,
                 sticky    : isSticky,
-            } }>
-            <Column
-                className     = { className }
-                size          = { size }
-                role          = { isHeader ? 'columnheader' : 'gridcell' }
-                columnTitle   = { columnTitle }
-                align         = { align }
-                verticalAlign = { verticalAlign }>
-                { contentNode }
-            </Column>
-        </Css>
+            } ) }
+            size          = { size }
+            role          = { isHeader ? 'columnheader' : 'gridcell' }
+            columnTitle   = { columnTitle }
+            align         = { align }
+            verticalAlign = { verticalAlign }>
+            { contentNode }
+        </Column>
     );
 };
 TableCell.propTypes =
 {
+    /**
+     *  Horizontal alignment of content (“auto” makes all items 100% width)
+     */
+    align       : PropTypes.oneOf( [ 'auto', 'left', 'center', 'right' ] ),
+    /**
+     *  Cell content
+     */
+    children    : PropTypes.node,
     /**
      *  Title of the column this cell in
      */
@@ -76,18 +81,13 @@ TableCell.propTypes =
      */
     isSticky    : PropTypes.bool,
     /**
-     *  Sort direction
+     *  Sorter onToggle callback function: ( e ) => { ... }
      */
-    sort        : PropTypes.oneOf( [
-        'asc',
-        'desc',
-        'none'
-    ] ),
-
+    onToggle    : PropTypes.func,
     /**
      *  Size of the cell
      */
-    size : PropTypes.oneOf( [
+    size        : PropTypes.oneOf( [
         'icon-S',
         'icon-M',
         'icon-L',
@@ -109,7 +109,7 @@ TableCell.propTypes =
         '1/14', '2/13', '3/13', '4/13', '5/13', '6/13', '7/13', '8/13', '9/13', '10/13', '11/13', '12/13', '13/13',
         '1/14', '2/14', '3/14', '4/14', '5/14', '6/14', '7/14', '8/14', '9/14', '10/14', '11/14', '12/14', '13/14', '14/14',
         '1/15', '2/15', '3/15', '4/15', '5/15', '6/15', '7/15', '8/15', '9/15', '10/15', '11/15', '12/15', '13/15', '14/15', '15/15',
-        '1/17', '2/17', '3/16', '4/16', '5/16', '6/16', '7/16', '8/16', '9/16', '10/16', '11/16', '12/16', '13/16', '14/16', '15/16', '16/16',
+        '1/16', '2/16', '3/16', '4/16', '5/16', '6/16', '7/16', '8/16', '9/16', '10/16', '11/16', '12/16', '13/16', '14/16', '15/16', '16/16',
         '1/17', '2/17', '3/17', '4/17', '5/17', '6/17', '7/17', '8/17', '9/17', '10/17', '11/17', '12/17', '13/17', '14/17', '15/17', '16/17', '17/17',
         '1/18', '2/18', '3/18', '4/18', '5/18', '6/18', '7/18', '8/18', '9/18', '10/18', '11/18', '12/18', '13/18', '14/18', '15/18', '16/18', '17/18', '18/18',
         '1/19', '2/19', '3/19', '4/19', '5/19', '6/19', '7/19', '8/19', '9/19', '10/19', '11/19', '12/19', '13/19', '14/19', '15/19', '16/19', '17/19', '18/19', '19/19',
@@ -122,40 +122,29 @@ TableCell.propTypes =
         /* eslint-enable max-len */
     ] ),
     /**
-     *  Horizontal alignment of content (“auto” makes all items 100% width)
+     *  Sort direction
      */
-    align : PropTypes.oneOf( [
-        'auto',
-        'left',
-        'center',
-        'right'
-    ] ),
+    sort          : PropTypes.oneOf( [ 'asc', 'desc', 'none' ] ),
     /**
      *  Vertical alignment of content (“auto” is equivalent to “top”)
      */
-    verticalAlign : PropTypes.oneOf( [
-        'auto',
-        'top',
-        'middle',
-        'bottom'
-    ] ),
-    /**
-     *  Cell content
-     */
-    children : PropTypes.node,
-    /**
-     *  Sorter onToggle callback function: ( e ) => { ... }
-     */
-    onToggle : PropTypes.func
+    verticalAlign : PropTypes.oneOf( [ 'auto', 'top', 'middle', 'bottom' ] ),
+
 };
 
 TableCell.defaultProps =
 {
-    isHeader    : false,
-    isRowHeader : false,
-    isSortable  : false,
-    isSticky    : false,
-    cssMap      : require( './tableCell.css' )
+    align         : undefined,
+    children      : undefined,
+    cssMap        : styles,
+    gutters       : undefined,
+    isHeader      : false,
+    isRowHeader   : false,
+    isSortable    : false,
+    isSticky      : false,
+    size          : undefined,
+    sort          : 'none',
+    verticalAlign : undefined,
 };
 
 export default TableCell;

--- a/src/TableCell/index.jsx
+++ b/src/TableCell/index.jsx
@@ -137,7 +137,6 @@ TableCell.defaultProps =
     align         : undefined,
     children      : undefined,
     cssMap        : styles,
-    gutters       : undefined,
     isHeader      : false,
     isRowHeader   : false,
     isSortable    : false,

--- a/src/TableRow/index.jsx
+++ b/src/TableRow/index.jsx
@@ -11,13 +11,14 @@ const TableRow = ( {
     cssMap,
     gutters,
     isSticky,
-    verticalAlign } ) =>
+    verticalAlign,
+} ) =>
 {
     const cells = React.Children.toArray( children ).map( cell =>
         React.cloneElement( cell,
             {
-                align         : align || cell.props.align,
-                verticalAlign : verticalAlign || cell.props.verticalAlign,
+                align         : cell.props.align || align,
+                verticalAlign : cell.props.verticalAlign || verticalAlign,
             }
         )
     );
@@ -82,9 +83,9 @@ TableRow.propTypes =
 
 TableRow.defaultProps =
 {
-    align         : 'auto',
-    verticalAlign : 'auto',
-    gutters       : 'L',
+    align         : undefined,
+    verticalAlign : undefined,
+    gutters       : undefined,
     isSticky      : false,
     cssMap        : require( './tableRow.css' )
 };

--- a/src/TableRow/index.jsx
+++ b/src/TableRow/index.jsx
@@ -1,8 +1,9 @@
-import React                from 'react';
-import PropTypes            from 'prop-types';
+import React              from 'react';
+import PropTypes          from 'prop-types';
 
-import Css                  from '../hoc/Css';
-import Row                  from '../Row';
+import Row                from '../Row';
+import { buildClassName } from '../utils';
+import styles             from './tableRow.css';
 
 const TableRow = ( {
     align,
@@ -24,19 +25,15 @@ const TableRow = ( {
     );
 
     return (
-        <Css
-            cssMap = { cssMap }
-            cssProps = { {
-                sticky : isSticky
-            } }>
-            <Row
-                className     = { className }
-                role          = "row"
-                gutters       = { gutters }
-                spacing       = "none">
-                { cells }
-            </Row>
-        </Css>
+        <Row
+            className = { buildClassName( className, cssMap, {
+                sticky : isSticky,
+            } ) }
+            role    = "row"
+            gutters = { gutters }
+            spacing = "none">
+            { cells }
+        </Row>
     );
 };
 
@@ -46,48 +43,34 @@ TableRow.propTypes =
      *  Globally sets cell horizonal alignment
      *  for this row (individual cell alignment will override)
      */
-    align : PropTypes.oneOf( [
-        'auto',
-        'left',
-        'center',
-        'right'
-    ] ),
+    align         : PropTypes.oneOf( [ 'auto', 'left', 'center', 'right' ] ),
+    /**
+     *  Row content (TableCells)
+     */
+    children      : PropTypes.node,
+    /**
+     *  Gutter size
+     */
+    gutters       : PropTypes.oneOf( [ 'none', 'S', 'M', 'L' ] ),
+    /**
+     *  Makes the row sticky
+     */
+    isSticky      : PropTypes.bool,
     /**
      *  Globally sets cell vertical alignment
      *  for this row (individual cell alignment will overrides)
      */
-    verticalAlign : PropTypes.oneOf( [
-        'auto',
-        'top',
-        'middle',
-        'bottom'
-    ] ),
-    /**
-     *  Gutter size
-     */
-    gutters : PropTypes.oneOf( [
-        'none',
-        'S',
-        'M',
-        'L'
-    ] ),
-    /**
-     *  Makes the row sticky
-     */
-    isSticky : PropTypes.bool,
-    /**
-     *  Row content (TableCells)
-     */
-    children : PropTypes.node
+    verticalAlign : PropTypes.oneOf( [ 'auto', 'top', 'middle', 'bottom' ] ),
 };
 
 TableRow.defaultProps =
 {
     align         : undefined,
-    verticalAlign : undefined,
+    children      : undefined,
+    cssMap        : styles,
     gutters       : undefined,
     isSticky      : false,
-    cssMap        : require( './tableRow.css' )
+    verticalAlign : undefined,
 };
 
 export default TableRow;


### PR DESCRIPTION
This PR:
- stops the Table component from overriding specific props set on specific TableRows and/or TableCells inside the Table (see #136)
- general tidy up