### PR TITLE
Issue 60 flounder fix

### DIFF
--- a/src/FlounderDropdown/index.jsx
+++ b/src/FlounderDropdown/index.jsx
@@ -258,6 +258,16 @@ export default class FlounderDropdown extends Component
         this.setDisabled();
     }
 
+    componentWillUnmount()
+    {
+        const { flounderInstance } = this;
+
+        if ( flounderInstance )
+        {
+            flounderInstance.destroy();
+        }
+    }
+
     setDisabled()
     {
         const { flounderInstance, props } = this;

--- a/src/FlounderDropdown/index.jsx
+++ b/src/FlounderDropdown/index.jsx
@@ -272,25 +272,32 @@ export default class FlounderDropdown extends Component
     {
         const { flounderInstance } = this;
 
-        if ( value && flounderInstance )
+        if ( flounderInstance )
         {
             let values = [];
 
-            if ( Array.isArray( value ) )
+            if ( value )
             {
-                values = value;
-            }
-            else if ( value )
-            {
-                values = [ value ];
+                if ( Array.isArray( value ) )
+                {
+                    values = value;
+                }
+                else if ( value )
+                {
+                    values = [ value ];
+                }
             }
 
-            const selectedValues = flounderInstance.getSelectedValues() || [];
-
-            if ( stringifyArr( selectedValues ) !== stringifyArr( values ) )
+            if ( value || this.props.isReadOnly )
             {
-                flounderInstance.deselectAll( true );
-                flounderInstance.setByValue( values );
+                const selectedValues =
+                    flounderInstance.getSelectedValues() || [];
+
+                if ( stringifyArr( selectedValues ) !== stringifyArr( values ) )
+                {
+                    flounderInstance.deselectAll( true );
+                    flounderInstance.setByValue( values );
+                }
             }
         }
     }

--- a/src/FlounderDropdown/index.jsx
+++ b/src/FlounderDropdown/index.jsx
@@ -265,6 +265,7 @@ export default class FlounderDropdown extends Component
         if ( flounderInstance )
         {
             flounderInstance.destroy();
+            this.flounderInstance = null;
         }
     }
 
@@ -352,19 +353,46 @@ export default class FlounderDropdown extends Component
                 search               : !props.isHeader && props.search
             };
 
-            const keepOpen = !!( flounderInstance &&
-                flounderInstance.refs.wrapper.className.match(
-                    props.cssMap.open ) );
+            const keepOpen = this.isOpen();
+
+            if ( flounderInstance && flounderInstance === flounderDiv.flounder )
+            {
+                flounderInstance.rebuild( flounderProps );
+            }
+            else
+            {
+                if ( flounderInstance )
+                {
+                    this.flounderInstance.destroy();
+                }
+
+                this.flounderInstance =
+                    new Flounder( flounderDiv, flounderProps );
+            }
 
             if ( keepOpen )
             {
-                flounderInstance.toggleList( {} );
+                flounderInstance.toggleList( new Event( {} ) );
             }
-
-            this.flounderInstance = flounderInstance ?
-                flounderInstance.rebuild( flounderProps ) :
-                new Flounder( flounderDiv, flounderProps );
         }
+    }
+
+    isOpen()
+    {
+        const { flounderInstance } = this;
+        const { cssMap } = this.props;
+
+        if ( flounderInstance )
+        {
+            const { wrapper } = flounderInstance.refs;
+
+            if ( wrapper.className.match( cssMap.open ) )
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     handleRef( node )
@@ -402,7 +430,7 @@ export default class FlounderDropdown extends Component
                 <Wrapper className = { className }>
                     <InputContainer { ...props } label = { !isHeader && label }>
                         <div
-                            ref = { this.handleRef }
+                            ref         = { this.handleRef }
                             onMouseOver = { onMouseOver }
                             onMouseOut  = { onMouseOut }
                         />

--- a/src/FlounderDropdown/index.jsx
+++ b/src/FlounderDropdown/index.jsx
@@ -1,4 +1,3 @@
-
 /* eslint max-len: ["error", { "ignoreTrailingComments": true }] */
 
 import React, { Component } from 'react';
@@ -11,14 +10,15 @@ import H1                   from '../H1';
 import H2                   from '../H2';
 import H3                   from '../H3';
 import H4                   from '../H4';
+import {
+    mapCssToFlounder,
+    mapIconClassesToFlounder,
+    stringifyArr,
+    stringifyObj,
+} from './utils';
+
 
 const headers = { 1: H1, 2: H2, 3: H3, 4: H4 };
-
-const stringifyObj = ( obj = {} ) =>
-    JSON.stringify( obj, ( key, val ) =>
-        ( typeof val === 'function' ? val.toString() : val ) );
-
-const stringifyArr = ( arr = [] ) => JSON.stringify( [ ...arr ].sort() );
 
 const rebuildOnProps = [
     'classes',
@@ -40,145 +40,9 @@ const rebuildOnProps = [
     'onOpen',
     'openOnHover',
     'placeholder',
-    'search'
+    'search',
 ];
 
-const buildFlounder = ( node, props = {} ) =>
-{
-    if ( node )
-    {
-        let flounder = node.flounder;
-
-        const keepOpen = !!( flounder &&
-            flounder.refs.wrapper.className.match( props.cssMap.open ) );
-
-        const onChange = ( ...args ) =>
-        {
-            const toChange = !props.isReadOnly && props.onChange;
-
-            if ( typeof props.value !== 'undefined' || props.isReadOnly )
-            {
-                setValue( flounder, props.value );
-            }
-
-            toChange && props.onChange( ...args );
-        };
-
-        const flounderProps =
-            {
-                classes : mapCssToFlounder( props.cssMap ),
-                data    : mapIconClassesToFlounder( props.data,
-                                                    props.cssMap ),
-                disableArrow         : props.icon === 'none',
-                multiple             : props.multiple,
-                multipleMessage      : props.multipleMessage,
-                multipleTags         : !props.isHeader && props.multipleTags,
-                noMoreOptionsMessage : props.noMoreOptionsMessage,
-                noMoreResultsMessage : props.noMoreResultsMessage,
-                onBlur               : props.onBlur,  // not yet implemented
-                onChange,
-                onClose              : props.onClose,
-                onFirstTouch         : props.onFirstTouch,
-                onFocus              : props.onFocus, // not yet implemented
-                onInputChange        : props.onInputChange,
-                onOpen               : props.onOpen,
-                openOnHover          : props.openOnHover,
-                placeholder          : props.placeholder,
-                search               : !props.isHeader && props.search
-            };
-
-        flounder = flounder ? flounder.rebuild( flounderProps ) :
-            new Flounder( node, flounderProps );
-
-        if ( keepOpen )
-        {
-            flounder.toggleList( {} );
-        }
-
-        return flounder;
-    }
-
-    return false;
-};
-
-const setValue = ( flounder, value ) =>
-{
-    if ( flounder )
-    {
-        let values = [];
-
-        if ( Array.isArray( value ) )
-        {
-            values = value;
-        }
-        else if ( value )
-        {
-            values = [ value ];
-        }
-
-        const selectedValues = flounder.getSelectedValues() || [];
-
-        if ( stringifyArr( selectedValues ) !== stringifyArr( values ) )
-        {
-            flounder.deselectAll( true );
-            flounder.setByValue( values );
-        }
-    }
-};
-
-const mapIconClassesToFlounder = ( data = [], cssMap = {} ) =>
-    data.map( datum =>
-    {
-        if ( typeof datum !== 'object' )
-        {
-            return datum;
-        }
-
-        return {
-            ...datum,
-            // eslint-disable-next-line key-spacing
-            data : datum.data && mapIconClassesToFlounder( datum.data, cssMap ),
-            extraClass : cssMap[ `optionIcon__${datum.icon}` ]
-        };
-    }
-);
-
-
-const mapCssToFlounder = ( cssMap = {} ) =>
-    /* commented classes are currently unused */
-     ( {
-         ARROW                 : cssMap.arrow,
-         ARROW_INNER           : cssMap.arrowInner,
-         DESCRIPTION           : cssMap.description,
-         DISABLED              : cssMap.disabled,
-         HEADER                : cssMap.header,
-         HIDDEN                : cssMap.hidden,
-         HIDDEN_IOS            : cssMap.hiddenIos,
-        // HOVER                   : cssMap.hover,
-         LIST                  : cssMap.list,
-         LOADING               : cssMap.loading,
-         LOADING_FAILED        : cssMap.loadingFailed,
-         MAIN                  : cssMap.main,
-         MAIN_WRAPPER          : cssMap.mainWrapper,
-         MULTIPLE_TAG_FLOUNDER : cssMap.multipleTag,
-         MULTI_TAG_LIST        : cssMap.multiTagList,
-         MULTIPLE_SELECT_TAG   : cssMap.multipleSelectTag,
-         MULTIPLE_TAG_CLOSE    : cssMap.multipleTagClose,
-         NO_RESULTS            : cssMap.noResults,
-         OPEN                  : cssMap.open,
-         OPTION                : cssMap.option,
-        // OPTION_TAG              : cssMap.optionTag,
-         OPTIONS_WRAPPER       : cssMap.optionsWrapper,
-         PLACEHOLDER           : cssMap.placeholder,
-        // PLUG                    : cssMap.plug,
-         SECTION               : cssMap.section,
-         SELECTED              : cssMap.selected,
-         SELECTED_HIDDEN       : cssMap.selectedHidden,
-         SELECTED_DISPLAYED    : cssMap.selectedDisplayed,
-         SEARCH                : cssMap.search,
-         SEARCH_HIDDEN         : cssMap.searchHidden,
-        // SELECT_TAG              : cssMap.selectTag
-     } );
 
 export default class FlounderDropdown extends Component
 {
@@ -357,7 +221,7 @@ export default class FlounderDropdown extends Component
         forceHover            : false,
         placeholder           : 'Please choose an option',
         icon                  : 'arrow',
-        cssMap                : require( './flounderDropdown.css' )
+        cssMap                : require( './flounderDropdown.css' ),
     };
 
     constructor( props )
@@ -366,22 +230,18 @@ export default class FlounderDropdown extends Component
         this.handleRef = this.handleRef.bind( this );
     }
 
-
     componentDidMount()
     {
-        const { flounderDiv, props } = this;
-        const flounder = buildFlounder( flounderDiv, props );
+        const { props } = this;
 
-        setValue( flounder, props.value || props.defaultValue );
-        flounder.disable( props.isDisabled );
-
-        this.flounderInstance = flounder;
+        this.buildFlounder();
+        this.setValue( props.value || props.defaultValue );
+        this.setDisabled();
     }
 
     componentDidUpdate( prevProps )
     {
-        const { flounderDiv, props } = this;
-        let { flounderInstance } = this;
+        const { props } = this;
 
         // eslint-disable-next-line no-restricted-syntax
         for ( const propName of rebuildOnProps )
@@ -389,13 +249,105 @@ export default class FlounderDropdown extends Component
             if ( stringifyObj( prevProps[ propName ] ) !==
                 stringifyObj( props[ propName ] ) )
             {
-                flounderInstance = buildFlounder( flounderDiv, props );
+                this.buildFlounder();
                 break;
             }
         }
 
-        setValue( flounderInstance, props.value );
-        flounderInstance.disable( props.isDisabled );
+        this.setValue();
+        this.setDisabled();
+    }
+
+    setDisabled()
+    {
+        const { flounderInstance, props } = this;
+
+        if ( flounderInstance )
+        {
+            flounderInstance.disable( props.isDisabled );
+        }
+    }
+
+    setValue( value = this.props.value )
+    {
+        const { flounderInstance } = this;
+
+        if ( value && flounderInstance )
+        {
+            let values = [];
+
+            if ( Array.isArray( value ) )
+            {
+                values = value;
+            }
+            else if ( value )
+            {
+                values = [ value ];
+            }
+
+            const selectedValues = flounderInstance.getSelectedValues() || [];
+
+            if ( stringifyArr( selectedValues ) !== stringifyArr( values ) )
+            {
+                flounderInstance.deselectAll( true );
+                flounderInstance.setByValue( values );
+            }
+        }
+    }
+
+    buildFlounder()
+    {
+        const { flounderDiv } = this;
+
+        if ( flounderDiv )
+        {
+            const { flounderInstance, props } = this;
+
+            const onChange = ( ...args ) =>
+            {
+                this.setValue();
+
+                if ( !props.isReadOnly && props.onChange )
+                {
+                    props.onChange( ...args );
+                }
+            };
+
+            const flounderProps = {
+                classes : mapCssToFlounder( props.cssMap ),
+                data    : mapIconClassesToFlounder( props.data,
+                    props.cssMap ),
+                disableArrow         : props.icon === 'none',
+                multiple             : props.multiple,
+                multipleMessage      : props.multipleMessage,
+                multipleTags         : !props.isHeader && props.multipleTags,
+                noMoreOptionsMessage : props.noMoreOptionsMessage,
+                noMoreResultsMessage : props.noMoreResultsMessage,
+                onBlur               : props.onBlur,  // not yet implemented
+                onChange,
+                onClose              : props.onClose,
+                onFirstTouch         : props.onFirstTouch,
+                onFocus              : props.onFocus, // not yet implemented
+                onInputChange        : props.onInputChange,
+                onOpen               : props.onOpen,
+                openOnHover          : props.openOnHover,
+                placeholder          : props.placeholder,
+                search               : !props.isHeader && props.search
+            };
+
+            const keepOpen = !!( flounderInstance &&
+                flounderInstance.refs.wrapper.className.match(
+                    props.cssMap.open ) );
+
+            if ( keepOpen )
+            {
+                flounderInstance.toggleList( {} );
+            }
+
+            this.flounderInstance = flounderInstance ?
+                flounderInstance.rebuild( flounderProps ) :
+                new Flounder( flounderDiv, flounderProps );
+        }
     }
 
     handleRef( node )
@@ -428,8 +380,7 @@ export default class FlounderDropdown extends Component
                     headerLevel,
                     toggleIcon  : icon,
                     error       : !isDisabled && hasError,
-                    fakeHovered : !isDisabled && !hasError &&
-                                              forceHover
+                    fakeHovered : !isDisabled && !hasError && forceHover
                 } }>
                 <Wrapper className = { className }>
                     <InputContainer { ...props } label = { !isHeader && label }>

--- a/src/FlounderDropdown/utils.js
+++ b/src/FlounderDropdown/utils.js
@@ -1,0 +1,66 @@
+const mapCssToFlounder = ( cssMap = {} ) =>
+    /* commented classes are currently unused */
+    ( {
+        ARROW                 : cssMap.arrow,
+        ARROW_INNER           : cssMap.arrowInner,
+        DESCRIPTION           : cssMap.description,
+        DISABLED              : cssMap.disabled,
+        HEADER                : cssMap.header,
+        HIDDEN                : cssMap.hidden,
+        HIDDEN_IOS            : cssMap.hiddenIos,
+        // HOVER                   : cssMap.hover,
+        LIST                  : cssMap.list,
+        LOADING               : cssMap.loading,
+        LOADING_FAILED        : cssMap.loadingFailed,
+        MAIN                  : cssMap.main,
+        MAIN_WRAPPER          : cssMap.mainWrapper,
+        MULTIPLE_TAG_FLOUNDER : cssMap.multipleTag,
+        MULTI_TAG_LIST        : cssMap.multiTagList,
+        MULTIPLE_SELECT_TAG   : cssMap.multipleSelectTag,
+        MULTIPLE_TAG_CLOSE    : cssMap.multipleTagClose,
+        NO_RESULTS            : cssMap.noResults,
+        OPEN                  : cssMap.open,
+        OPTION                : cssMap.option,
+        // OPTION_TAG              : cssMap.optionTag,
+        OPTIONS_WRAPPER       : cssMap.optionsWrapper,
+        PLACEHOLDER           : cssMap.placeholder,
+        // PLUG                    : cssMap.plug,
+        SECTION               : cssMap.section,
+        SELECTED              : cssMap.selected,
+        SELECTED_HIDDEN       : cssMap.selectedHidden,
+        SELECTED_DISPLAYED    : cssMap.selectedDisplayed,
+        SEARCH                : cssMap.search,
+        SEARCH_HIDDEN         : cssMap.searchHidden,
+        // SELECT_TAG              : cssMap.selectTag
+    } );
+
+const mapIconClassesToFlounder = ( data = [], cssMap = {} ) =>
+    data.map( datum =>
+    {
+        if ( typeof datum !== 'object' )
+        {
+            return datum;
+        }
+
+        return {
+            ...datum,
+            data : datum.data &&
+                mapIconClassesToFlounder( datum.data, cssMap ),
+            extraClass : cssMap[ `optionIcon__${datum.icon}` ]
+        };
+    } );
+
+
+const stringifyArr = ( arr = [] ) => JSON.stringify( [ ...arr ].sort() );
+
+const stringifyObj = ( obj = {} ) =>
+    JSON.stringify( obj, ( key, val ) =>
+        ( typeof val === 'function' ? val.toString() : val ) );
+
+
+export {
+    mapCssToFlounder,
+    mapIconClassesToFlounder,
+    stringifyArr,
+    stringifyObj,
+};


### PR DESCRIPTION
For #60:
- remove the reference to `props.value` inside `onChange` handler (fixes the bug in #60)

also:
- move some utils functions to separate file
- move `buildFlounder` and `setValue` to the FlounderDropdown class
- implement `setDisabled` function on FlounderDropdown class
- implement a separate `isOpen` function to test whether the dropdown is open
- `destroy()` flounder on unmount
