### PR TITLE
Deprecate Grid “hasMinHeight” prop #251

### DIFF
--- a/src/Grid/grid.css
+++ b/src/Grid/grid.css
@@ -190,8 +190,3 @@
 {
     flex-wrap:      wrap;
 }
-
-.hasMinHeight
-{
-    min-height: 7.1rem; /* label + input */
-}

--- a/src/Grid/index.jsx
+++ b/src/Grid/index.jsx
@@ -15,20 +15,30 @@ const Grid = ( {
     role,
     spacing,
     verticalAlign,
-} ) => (
-    <div
-        className = { buildClassName( className, cssMap, {
-            alignX  : align,
-            alignY  : verticalAlign,
-            hasMinHeight,
-            gutters : gutters !== 'none' && gutters,
-            hasWrap,
-            spacing : spacing !== 'none' && spacing
-        } ) }
-        role = { role }>
-        { children }
-    </div>
-);
+} ) =>
+{
+    if ( !Grid.didWarn && hasMinHeight )
+    {
+        console.warn( 'Grid: hasMinHeight prop is deprecated. Please use an \
+alternative layout.' );
+        Grid.didWarn = true;
+    }
+
+    return (
+        <div
+            className = { buildClassName( className, cssMap, {
+                alignX  : align,
+                alignY  : verticalAlign,
+                hasMinHeight,
+                gutters : gutters !== 'none' && gutters,
+                hasWrap,
+                spacing : spacing !== 'none' && spacing
+            } ) }
+            role = { role }>
+            { children }
+        </div>
+    );
+};
 
 Grid.propTypes =
 {
@@ -36,39 +46,35 @@ Grid.propTypes =
      * Horizontal alignment of the columns (“auto” makes all columns equal
      * width)
      */
-    align        : PropTypes.oneOf( [ 'auto', 'left', 'center', 'right' ] ),
+    align     : PropTypes.oneOf( [ 'auto', 'left', 'center', 'right' ] ),
     /**
      *  Grid content (Columns)
      */
-    children     : PropTypes.node,
+    children  : PropTypes.node,
     /**
      *  CSS class name
      */
-    className    : PropTypes.string,
+    className : PropTypes.string,
     /**
      *  CSS class map
      */
-    cssMap       : PropTypes.objectOf( PropTypes.string ),
+    cssMap    : PropTypes.objectOf( PropTypes.string ),
     /**
      *  Gutter size
      */
-    gutters      : PropTypes.oneOf( [ 'none', 'S', 'M', 'L' ] ),
-    /**
-    *  Set minimum height equal to average row.
-    */
-    hasMinHeight : PropTypes.bool,
+    gutters   : PropTypes.oneOf( [ 'none', 'S', 'M', 'L' ] ),
     /**
      * Wrap content
      */
-    hasWrap      : PropTypes.bool,
+    hasWrap   : PropTypes.bool,
     /**
      *  Grid role
      */
-    role         : PropTypes.string,
+    role      : PropTypes.string,
     /**
      *  Row spacing
      */
-    spacing      : PropTypes.oneOf( [
+    spacing   : PropTypes.oneOf( [
         'none',
         'default',
         'h1',
@@ -91,7 +97,6 @@ Grid.defaultProps =
     className     : undefined,
     cssMap        : styles,
     gutters       : 'L',
-    hasMinHeight  : false,
     hasWrap       : true,
     role          : undefined,
     spacing       : 'default',

--- a/src/Row/index.jsx
+++ b/src/Row/index.jsx
@@ -11,35 +11,31 @@ Row.propTypes =
      * Horizontal alignment of the columns (“auto” makes all columns equal
      * width)
      */
-    align        : PropTypes.oneOf( [ 'auto', 'left', 'center', 'right' ] ),
+    align     : PropTypes.oneOf( [ 'auto', 'left', 'center', 'right' ] ),
     /**
      *  Row content (Columns)
      */
-    children     : PropTypes.node,
+    children  : PropTypes.node,
     /**
      *  CSS class name
      */
-    className    : PropTypes.string,
+    className : PropTypes.string,
     /**
      *  CSS class map
      */
-    cssMap       : PropTypes.objectOf( PropTypes.string ),
+    cssMap    : PropTypes.objectOf( PropTypes.string ),
     /**
      *  Gutter size
      */
-    gutters      : PropTypes.oneOf( [ 'none', 'S', 'M', 'L' ] ),
-    /**
-    *  Set minimum height equal to average row.
-    */
-    hasMinHeight : PropTypes.bool,
+    gutters   : PropTypes.oneOf( [ 'none', 'S', 'M', 'L' ] ),
     /**
      *  Row role
      */
-    role         : PropTypes.string,
+    role      : PropTypes.string,
     /**
      *  Row spacing
      */
-    spacing      : PropTypes.oneOf( [
+    spacing   : PropTypes.oneOf( [
         'none',
         'default',
         'h1',
@@ -62,7 +58,6 @@ Row.defaultProps =
     className     : undefined,
     cssMap        : undefined,
     gutters       : 'L',
-    hasMinHeight  : false,
     role          : undefined,
     spacing       : 'default',
     verticalAlign : 'auto',


### PR DESCRIPTION
For #251:
- adds a deprecation warning for Grid `hasMinHeight` prop
- removes `hasMinHeight` from Grid/Row PropTypes spec