### PR TITLE
Adds minHeight prop/functionality to CodeEditor

### DIFF
--- a/src/CodeEditor/codeEditor.css
+++ b/src/CodeEditor/codeEditor.css
@@ -15,6 +15,50 @@
             border: 0.1rem solid var( --PC-BLUE );
         }
     }
+
+    :global .CodeMirror
+    {
+        box-sizing:     border-box;
+        height:         100%;
+        padding:        0;
+        background:     transparent;
+        line-height:    initial;
+
+        font-family:    monospace, sans-serif;
+        font-size:      1.1rem;
+
+        &-sizer
+        {
+            margin-left:    0 !important;
+        }
+
+        &-gutters
+        {
+            border:             none;
+            background-color:   transparent;
+            left:               0 !important;
+        }
+
+        &-gutter-wrapper
+        {
+            left:   0 !important;
+        }
+
+        &-linenumber
+        {
+            white-space:    normal;
+        }
+
+        &-lines
+        {
+            padding:    0.8rem 0 0.9rem 0;
+        }
+
+        &-line
+        {
+            text-indent:    4rem;
+        }
+    }
 }
 
 .error
@@ -34,59 +78,4 @@
         background:     var( --GS-10 ) !important;
         color:          color( var( --GS-2 ) a( 50% ) ) !important;
     }
-}
-
-
-
-
-
-
-
-:global
-{
-    .CodeMirror
-    {
-        box-sizing:     border-box;
-        height:         100%;
-        padding:        0.8rem 0 0.9rem 0;
-        background:     transparent;
-        line-height:    initial;
-
-        font-family:    monospace, sans-serif;
-        font-size:      1.1rem;
-    }
-
-    .CodeMirror-sizer
-    {
-        margin-left:        0 !important;
-    }
-
-    .CodeMirror-gutters
-    {
-        border:             none;
-        background-color:   transparent;
-        left:               0 !important;
-    }
-
-    .CodeMirror-gutter-wrapper
-    {
-        left:               0 !important;
-    }
-
-    .CodeMirror-linenumber
-    {
-        white-space:    normal;
-    }
-
-    .CodeMirror-line
-    {
-        text-indent:    4rem;
-    }
-}
-
-:global @keyframes blink
-{
-  0% {}
-  50% { background-color: transparent; }
-  100% {}
 }

--- a/src/CodeEditor/codeEditor.css
+++ b/src/CodeEditor/codeEditor.css
@@ -51,7 +51,7 @@
 
         &-lines
         {
-            padding:    0.8rem 0 0.9rem 0;
+            padding:    0.8rem 1rem 0.9rem 1rem;
         }
 
         &-line

--- a/src/CodeEditor/codemirror.css
+++ b/src/CodeEditor/codemirror.css
@@ -338,3 +338,10 @@
     /* Help users use markselection to safely style text background */
     span.CodeMirror-selectedtext { background: none; }
 }
+
+:global @keyframes blink
+{
+  0% {}
+  50% { background-color: transparent; }
+  100% {}
+}

--- a/src/CodeEditor/index.jsx
+++ b/src/CodeEditor/index.jsx
@@ -5,6 +5,7 @@ import PropTypes            from 'prop-types';
 
 import Css                  from '../hoc/Css';
 import InputContainer       from '../proto/InputContainer';
+import styles               from './codeEditor.css';
 
 import 'codemirror/mode/jsx/jsx';
 
@@ -12,6 +13,8 @@ const defaultOptions = {
     lineNumbers  : true,
     lineWrapping : true
 };
+
+const SCROLL_CLASS = 'CodeMirror-scroll';
 
 export default class CodeEditor extends Component
 {
@@ -33,6 +36,10 @@ export default class CodeEditor extends Component
          *  Code editor height (CSS length value)
          */
         height                : PropTypes.string,
+        /**
+         *  Code editor max height (CSS length value)
+         */
+        maxHeight             : PropTypes.string,
         /**
          *  Display as disabled
          */
@@ -108,14 +115,16 @@ export default class CodeEditor extends Component
 
     static defaultProps =
     {
-        labelPosition         : 'top',
-        isDisabled            : false,
-        isReadOnly            : false,
-        hasError              : false,
+        cssMap                : styles,
         errorMessageIsVisible : false,
         errorMessagePosition  : 'top',
         forceHover            : false,
-        cssMap                : require( './codeEditor.css' )
+        hasError              : false,
+        height                : undefined,
+        isDisabled            : false,
+        isReadOnly            : false,
+        labelPosition         : 'top',
+        maxHeight             : undefined,
     };
 
     constructor( props )
@@ -129,6 +138,7 @@ export default class CodeEditor extends Component
         this.handleChange         = this.handleChange.bind( this );
         this.handleCursorActivity = this.handleCursorActivity.bind( this );
         this.handleTextareaRef    = this.handleTextareaRef.bind( this );
+        this.handleWrapperRef     = this.handleWrapperRef.bind( this );
     }
 
     componentDidMount()
@@ -172,6 +182,8 @@ export default class CodeEditor extends Component
         }
 
         this.codeMirror = codeMirror;
+
+        this.setMaxHeight();
     }
 
     componentWillUpdate( nextProps )
@@ -224,6 +236,8 @@ export default class CodeEditor extends Component
         {
             codeMirror.setCursor( cursor );
         }
+
+        this.setMaxHeight();
     }
 
     componentWillUnmount()
@@ -236,6 +250,20 @@ export default class CodeEditor extends Component
         if ( codeMirrorRef )
         {
             codeMirrorRef( null );
+        }
+    }
+
+    setMaxHeight()
+    {
+        const { wrapper }   = this;
+        const { maxHeight } = this.props;
+
+        if ( wrapper && maxHeight )
+        {
+            const scrollEl =
+                wrapper.getElementsByClassName( SCROLL_CLASS )[ 0 ];
+
+            scrollEl.style.maxHeight = String( maxHeight );
         }
     }
 
@@ -287,6 +315,14 @@ export default class CodeEditor extends Component
         }
     }
 
+    handleWrapperRef( ref )
+    {
+        if ( ref )
+        {
+            this.wrapper = ref;
+        }
+    }
+
     render()
     {
         const {
@@ -298,9 +334,10 @@ export default class CodeEditor extends Component
 
         const {
             forceHover,
-            isDisabled,
             hasError,
             height,
+            isDisabled,
+            maxHeight,
             value,
         } = props;
 
@@ -318,7 +355,11 @@ export default class CodeEditor extends Component
                 <InputContainer { ...props } className = { className }>
                     <div
                         className = { cssMap.editor }
-                        style     = { { height: `${height}` } }>
+                        ref       = { this.handleWrapperRef }
+                        style     = { {
+                            height    : String( height ),
+                            maxHeight : String( maxHeight ),
+                        } }>
                         <textarea
                             ref          = { this.handleTextareaRef }
                             defaultValue = { value }


### PR DESCRIPTION
This PR  adds `maxHeight` prop and functionality to the CodeEditor component. 

In order to achieve this we need to add the `max-height` CSS property to a specific internal CodeMirror div (`.CodeMirror-scroll`). Since React does not know about the internal markup of CodeMirror, we need to use `getElementsByClassName` to locate that div after the CodeEditor mounts or updates.