### PR TITLE
Added inputRef prop to Slider #337

### DIFF
--- a/src/Slider/index.jsx
+++ b/src/Slider/index.jsx
@@ -227,7 +227,10 @@ export default class Slider extends Component
 
     componentDidUpdate( prevProps )
     {
-        if ( prevProps.value.length !== this.props.value.length )
+        const { props } = this;
+
+        if ( prevProps.inputRef !== props.inputRef ||
+            prevProps.value.length !== props.value.length )
         {
             this.attachInputRefs();
         }

--- a/src/Slider/index.jsx
+++ b/src/Slider/index.jsx
@@ -214,16 +214,14 @@ export default class Slider extends Component
 
     componentDidMount()
     {
-        this.setInputRefs();
+        this.attachInputRefs();
     }
 
     componentWillUpdate( nextProps )
     {
-        const { inputRef } = this.props;
-
-        if ( inputRef && nextProps.inputRef !== inputRef )
+        if ( nextProps.inputRef !== this.props.inputRef )
         {
-            inputRef( null );
+            this.detachInputRefs();
         }
     }
 
@@ -231,21 +229,16 @@ export default class Slider extends Component
     {
         if ( prevProps.value.length !== this.props.value.length )
         {
-            this.setInputRefs();
+            this.attachInputRefs();
         }
     }
 
     componentWillUnmount()
     {
-        const { inputRef } = this.props;
-
-        if ( inputRef )
-        {
-            inputRef( null );
-        }
+        this.detachInputRefs();
     }
 
-    setInputRefs()
+    attachInputRefs()
     {
         const { inputRef } = this.props;
 
@@ -265,6 +258,16 @@ export default class Slider extends Component
             {
                 inputRef( null );
             }
+        }
+    }
+
+    detachInputRefs()
+    {
+        const { inputRef } = this.props;
+
+        if ( inputRef )
+        {
+            inputRef( null );
         }
     }
 

--- a/src/Slider/index.jsx
+++ b/src/Slider/index.jsx
@@ -28,7 +28,8 @@ export default class Slider extends Component
         */
         hasError              : PropTypes.bool,
         /**
-        *  Ref to native input; or array of refs to native inputs
+        *  Callback that receives ref to native input; or array of refs to
+        *  native inputs
         */
         inputRef              : PropTypes.func,
         /**

--- a/src/Slider/index.jsx
+++ b/src/Slider/index.jsx
@@ -28,6 +28,10 @@ export default class Slider extends Component
         */
         hasError              : PropTypes.bool,
         /**
+        *  Ref to native input; or array of refs to native inputs
+        */
+        inputRef              : PropTypes.func,
+        /**
         *  Tooltip message text (string or JSX)
         */
         errorMessage          : PropTypes.node,
@@ -207,6 +211,61 @@ export default class Slider extends Component
         this.handleMouseUp   = this.handleMouseUp.bind( this );
     }
 
+    componentDidMount()
+    {
+        this.setInputRefs();
+    }
+
+    componentWillUpdate( nextProps )
+    {
+        const { inputRef } = this.props;
+
+        if ( inputRef && nextProps.inputRef !== inputRef )
+        {
+            inputRef( null );
+        }
+    }
+
+    componentDidUpdate( prevProps )
+    {
+        if ( prevProps.value.length !== this.props.value.length )
+        {
+            this.setInputRefs();
+        }
+    }
+
+    componentWillUnmount()
+    {
+        const { inputRef } = this.props;
+
+        if ( inputRef )
+        {
+            inputRef( null );
+        }
+    }
+
+    setInputRefs()
+    {
+        const { inputRef } = this.props;
+
+        if ( inputRef )
+        {
+            const inputs = Array.from( this.inputContainer.childNodes );
+
+            if ( inputs.length === 1 )
+            {
+                inputRef( inputs[ 0 ] );
+            }
+            else if ( inputs.length > 1 )
+            {
+                inputRef( inputs )
+            }
+            else
+            {
+                inputRef( null );
+            }
+        }
+    }
 
     /**
     * Generate track fill style object depending on input values

--- a/src/Slider/index.jsx
+++ b/src/Slider/index.jsx
@@ -241,6 +241,7 @@ export default class Slider extends Component
         this.detachInputRefs();
     }
 
+    /* eslint-disable react/sort-comp */
     attachInputRefs()
     {
         const { inputRef } = this.props;
@@ -255,7 +256,7 @@ export default class Slider extends Component
             }
             else if ( inputs.length > 1 )
             {
-                inputRef( inputs )
+                inputRef( inputs );
             }
             else
             {


### PR DESCRIPTION
For #337. This PR adds an `inputRef` callback ref prop to the Slider component. It behaves similar to the `inputRef` prop on other components, except:
- in the case of a single value/handle the `inputRef` callback will receive a single ref to the native `<input>`
- in the case of multiple values/handles the callback will receive an array of refs
- when the length of the `value` prop changes, `inputRef` gets called again with new ref(s)

Since the above behavior for multiple refs isn’t possible to implement directly using the native React `ref` mechanism, I have implemented it in `componentDidMount`/`componentDidUpdate`.

The behavior of native `ref`s is also mimicked in `componentWillUpdate`, `componentWillUnmount` (calling with `null` on detaching the ref).
