### PR TITLE
Removed broken driver pattern that overwrites event target #346

### DIFF
--- a/src/Checkbox/driver.js
+++ b/src/Checkbox/driver.js
@@ -11,28 +11,35 @@ export default class CheckboxDriver extends InputComponentDriver
 
     setChecked()
     {
-        this.control.node.checked = true;
-        const value = this.control.node.value;
-        this.control.simulate( 'change', { target: { checked: true, value } } );
+        const node = this.control.getNode();
+
+        if ( !node.checked )
+        {
+            node.checked  = true;
+            this.control.simulate( 'change' );
+        }
+
         return this;
     }
 
     setUnchecked()
     {
-        this.control.node.checked = false;
-        const value = this.control.node.value;
-        this.control.simulate( 'change',
-            { target: { checked: false, value } } );
+        const node = this.control.getNode();
+
+        if ( node.checked )
+        {
+            node.checked = false;
+            this.control.simulate( 'change' );
+        }
+
         return this;
     }
 
     toggleChecked()
     {
-        const status = this.getChecked();
-        const value = this.control.node.value;
-        this.control.node.checked = !status;
-        this.control.simulate( 'change',
-            { target: { checked: !status, value } } );
+        const node   = this.control.getNode();
+        node.checked = !node.checked;
+        this.control.simulate( 'change' );
         return this;
     }
 

--- a/src/Checkbox/tests.jsx
+++ b/src/Checkbox/tests.jsx
@@ -103,48 +103,74 @@ describe( 'CheckboxDriver', () =>
 
     describe( 'setChecked()', () =>
     {
-        it( 'should call onChange once', () =>
+        it( 'should not call onChange when already checked', () =>
         {
             const onChange = sinon.spy();
-            wrapper.setProps( { onChange } );
+            wrapper.setProps( { isChecked: true, onChange } );
+
+            wrapper.driver().setChecked();
+
+            expect( onChange.calledOnce ).to.be.false;
+        } );
+
+        it( 'should call onChange once when unchecked', () =>
+        {
+            const onChange = sinon.spy();
+            wrapper.setProps( { isChecked: false, onChange } );
 
             wrapper.driver().setChecked();
 
             expect( onChange.calledOnce ).to.be.true;
         } );
 
-        it( 'should be called with checked as true', () =>
+        it( 'should set target.checked to true', () =>
         {
-            const onChange = sinon.spy();
-            wrapper.setProps( { onChange } );
+            let targetChecked;
+            const onChange = sinon.stub().callsFake( e =>
+                targetChecked = e.target.checked
+            );
+            wrapper.setProps( { isChecked: false, onChange } );
 
             wrapper.driver().setChecked();
 
-            expect( onChange.lastCall.args[ 0 ].target.checked ).to.be.true;
+            expect( targetChecked ).to.be.true;
         } );
     } );
 
 
     describe( 'setUnchecked()', () =>
     {
-        it( 'should call onChange once', () =>
+        it( 'should not call onChange when already unchecked', () =>
         {
             const onChange = sinon.spy();
-            wrapper.setProps( { onChange } );
+            wrapper.setProps( { isChecked: false, onChange } );
+
+            wrapper.driver().setUnchecked();
+
+            expect( onChange.calledOnce ).to.be.false;
+        } );
+
+        it( 'should call onChange once when checked', () =>
+        {
+            const onChange = sinon.spy();
+            wrapper.setProps( { isChecked: true, onChange } );
 
             wrapper.driver().setUnchecked();
 
             expect( onChange.calledOnce ).to.be.true;
         } );
 
-        it( 'should be called with checked as false', () =>
+        it( 'should set target.checked to false', () =>
         {
-            const onChange = sinon.spy();
-            wrapper.setProps( { onChange } );
+            let targetChecked;
+            const onChange = sinon.stub().callsFake( e =>
+                targetChecked = e.target.checked
+            );
+            wrapper.setProps( { isChecked: true, onChange } );
 
             wrapper.driver().setUnchecked();
 
-            expect( onChange.lastCall.args[ 0 ].target.checked ).to.be.false;
+            expect( targetChecked ).to.be.false;
         } );
     } );
 
@@ -161,14 +187,17 @@ describe( 'CheckboxDriver', () =>
             expect( onChange.calledOnce ).to.be.true;
         } );
 
-        it( 'should toggle the value of checked', () =>
+        it( 'should toggle the value of target.checked', () =>
         {
-            const onChange = sinon.spy();
+            let targetChecked;
+            const onChange = sinon.stub().callsFake( e =>
+                targetChecked = e.target.checked
+            );
             wrapper.setProps( { onChange, isChecked: true } );
 
             wrapper.driver().toggleChecked();
 
-            expect( onChange.lastCall.args[ 0 ].target.checked ).to.be.false;
+            expect( targetChecked ).to.be.false;
         } );
     } );
 

--- a/src/DateTimeInput/driver.js
+++ b/src/DateTimeInput/driver.js
@@ -14,15 +14,15 @@ export default class DateTimeInputDriver
 
     getMainInputValue()
     {
-        return this.mainInput.node.value;
+        return this.mainInput.getNode().value;
     }
 
     setMainInputValue( value )
     {
-        const newValue = ( value == null ) ? '' : String( value );
+        const node = this.mainInput.getNode();
 
-        this.mainInput.node.value = value;
-        this.mainInput.simulate( 'change', { target: { value: newValue } } );
+        node.value = value;
+        this.mainInput.simulate( 'change' );
 
         return this;
     }
@@ -41,15 +41,15 @@ export default class DateTimeInputDriver
 
     getHourInputValue()
     {
-        return this.hourInput.node.value;
+        return this.hourInput.getNode().value;
     }
 
     setHourInputValue( value )
     {
-        const newValue = ( value == null ) ? '' : String( value );
+        const node = this.hourInput.getNode();
 
-        this.hourInput.node.value = value;
-        this.hourInput.simulate( 'change', { target: { value: newValue } } );
+        node.value = value;
+        this.hourInput.simulate( 'change' );
 
         return this;
     }
@@ -68,15 +68,15 @@ export default class DateTimeInputDriver
 
     getMinuteInputValue()
     {
-        return this.minuteInput.node.value;
+        return this.minuteInput.getNode().value;
     }
 
     setMinuteInputValue( value )
     {
-        const newValue = ( value == null ) ? '' : String( value );
+        const node = this.minuteInput.getNode();
 
-        this.minuteInput.node.value = value;
-        this.minuteInput.simulate( 'change', { target: { value: newValue } } );
+        node.value = value;
+        this.minuteInput.simulate( 'change' );
 
         return this;
     }

--- a/src/ScrollBox/driver.js
+++ b/src/ScrollBox/driver.js
@@ -7,8 +7,9 @@ export default class ScrollBoxDriver
 {
     constructor( wrapper )
     {
-        this.wrapper = wrapper;
-        this.props = this.wrapper.props();
+        this.wrapper   = wrapper;
+        this.props     = this.wrapper.props();
+        this.scrollBox = this.wrapper.find( '.scrollBox__scrollBox' );
     }
 
     clickScrollUp()
@@ -77,9 +78,10 @@ export default class ScrollBoxDriver
             );
         }
 
-        this.wrapper.find( '.scrollBox__scrollBox' ).simulate( 'scroll', {
-            target : { scrollTop: scrollOffset }
-        } );
+        const node     = this.scrollBox.getNode();
+        node.scrollTop = scrollOffset;
+        this.scrollBox.simulate( 'scroll' );
+
         return this;
     }
 
@@ -93,9 +95,11 @@ export default class ScrollBoxDriver
             );
         }
 
-        this.wrapper.find( '.scrollBox__scrollBox' ).simulate( 'scroll', {
-            target : { scrollLeft: scrollOffset }
-        } );
+        const node      = this.scrollBox.getNode();
+        node.scrollLeft = scrollOffset;
+        this.scrollBox.simulate( 'scroll' );
+
+
         return this;
     }
 }

--- a/src/ScrollBox/tests.jsx
+++ b/src/ScrollBox/tests.jsx
@@ -137,25 +137,9 @@ describe( 'ScrollBoxDriver', () =>
 
                 wrapper = mount( <ScrollBox { ...props } /> );
 
-                wrapper.driver().scrollVertical( 0.25 );
+                wrapper.driver().scrollVertical( 250 );
 
                 expect( onScroll.calledOnce ).to.be.true;
-            } );
-
-            it( 'should call onScroll with scrollOffset', () =>
-            {
-                const onScroll = sinon.spy();
-                const props = {
-                    scroll : 'vertical',
-                    onScroll
-                };
-
-                wrapper = mount( <ScrollBox { ...props } /> );
-
-                wrapper.driver().scrollVertical( 0.72 );
-
-                expect( onScroll.lastCall.args[ 0 ].target.scrollTop )
-                    .to.equal( 0.72 );
             } );
 
             it( 'should throw an error when scroll direction is wrong', () =>
@@ -166,7 +150,7 @@ describe( 'ScrollBoxDriver', () =>
 
                 wrapper = mount( <ScrollBox { ...props } /> );
 
-                expect( () => wrapper.driver().scrollVertical( 0.1 ) )
+                expect( () => wrapper.driver().scrollVertical( 10 ) )
                     .to.throw( 'Cannot scroll because scroll direction is neither \'vertical\' nor \'both\'' ); // eslint-disable-line max-len
             } );
         } );
@@ -183,25 +167,9 @@ describe( 'ScrollBoxDriver', () =>
 
                 wrapper = mount( <ScrollBox { ...props } /> );
 
-                wrapper.driver().scrollHorizontal( 0.64 );
+                wrapper.driver().scrollHorizontal( 640 );
 
                 expect( onScroll.calledOnce ).to.be.true;
-            } );
-
-            it( 'should call onScroll with scrollOffset', () =>
-            {
-                const onScroll = sinon.spy();
-                const props = {
-                    scroll : 'horizontal',
-                    onScroll
-                };
-
-                wrapper = mount( <ScrollBox { ...props } /> );
-
-                wrapper.driver().scrollHorizontal( 0.48 );
-
-                expect( onScroll.lastCall.args[ 0 ].target.scrollLeft )
-                    .to.equal( 0.48 );
             } );
 
             it( 'should throw an error when scroll direction is wrong', () =>
@@ -212,7 +180,7 @@ describe( 'ScrollBoxDriver', () =>
 
                 wrapper = mount( <ScrollBox { ...props } /> );
 
-                expect( () => wrapper.driver().scrollHorizontal( 0.27 ) )
+                expect( () => wrapper.driver().scrollHorizontal( 270 ) )
                     .to.throw( 'Cannot scroll because scroll direction is neither \'horizontal\' nor \'both\'' ); // eslint-disable-line max-len
             } );
         } );

--- a/src/Slider/driver.js
+++ b/src/Slider/driver.js
@@ -38,9 +38,12 @@ export default class SliderDriver
             throw new Error( ERRORS.DISABLED( this.label, 'changed' ) );
         }
 
-        this.inputContainer.childAt( index ).simulate( 'change', {
-            target : { value }
-        } );
+        const input = this.inputContainer.childAt( index );
+        const node  = input.getNode();
+
+        node.value = value;
+        input.simulate( 'change' );
+
         return this;
     }
 

--- a/src/Switch/driver.js
+++ b/src/Switch/driver.js
@@ -28,8 +28,8 @@ export default class SwitchDriver extends SimpleComponentDriver
             );
         }
 
-        this.input.simulate( 'change',
-            { target: { checked: !props.isChecked } } );
+        this.input.checked = !this.input.checked;
+        this.input.simulate( 'change' );
 
         return this.wrapper;
     }

--- a/src/Testing/CommonDrivers/inputComponentDriver.js
+++ b/src/Testing/CommonDrivers/inputComponentDriver.js
@@ -26,13 +26,14 @@ export default class InputComponentDriver extends ClickableComponentDriver
     setInputValue( value )
     {
         checkIfSimulationIsValid( this.wrapper,
-                                  ERRORS.INPUT_CANNOT_CHANGE_VALUE );
+            ERRORS.INPUT_CANNOT_CHANGE_VALUE );
 
-        const newValue = ( value == null ) ? '' : String( value );
-        const $input = this.control;
+        const input = this.control;
+        const node  = input.getNode();
+
         this.focus();
-        $input.node.value = value;
-        $input.simulate( 'change', { target: { value: newValue } } );
+        node.value = value;
+        input.simulate( 'change' );
         this.blur();
 
         return this;
@@ -58,10 +59,10 @@ export default class InputComponentDriver extends ClickableComponentDriver
 
         if ( isCharPrintable( keyCode ) )
         {
-            this.control.node.value += String.fromCharCode( keyCode );
-            this.control.simulate( 'change', {
-                target : { value: this.control.node.value }
-            } );
+            const node = this.control.getNode();
+
+            node.value += String.fromCharCode( keyCode );
+            this.control.simulate( 'change' );
         }
 
         this.control.simulate( 'keyUp', { which: keyCode } );
@@ -100,7 +101,7 @@ export default class InputComponentDriver extends ClickableComponentDriver
      */
     getInputValue()
     {
-        return this.control.node.value;
+        return this.control.getNode().value;
     }
 
     click()


### PR DESCRIPTION
For #346. This PR:
- __Removes an incorrect pattern found in test drivers that was overwriting `event.target`__
- Fixes behavior of `setChecked()` and `setUnChecked()` Checkbox driver methods so that they don’t fire `onChange` if no change has taken place
- Removed instances of `wrapper.node`; replaced with `wrapper.getNode()` (prep for Enzyme 3)
- Removed untestable test cases from ScrollBox (jsdom does not allow us to test scrolling afaik)
