### PR TITLE
Prevent CodeEditor from firing onChange when value prop changes #359

### DIFF
--- a/src/CodeEditor/index.jsx
+++ b/src/CodeEditor/index.jsx
@@ -298,10 +298,10 @@ export default class CodeEditor extends Component
         }
     }
 
-    handleChange( cm )
+    handleChange( cm, change )
     {
         const { onChange } = this.props;
-        if ( onChange )
+        if ( onChange && change.origin !== 'setValue' )
         {
             onChange( cm.getValue() );
         }


### PR DESCRIPTION
For #359:
- Checks the origin of the change before triggering `onChange` callback prop (if the origin was `setValue` don’t fire it)