### PR TITLE
CodeEditorDriver setValue should call onChange

### DIFF
--- a/src/CodeEditor/driver.js
+++ b/src/CodeEditor/driver.js
@@ -1,5 +1,7 @@
+/* global document */
+
 const ERRORS = {
-    EDITOR_READ_ONLY : 'Cannot change the CodeEditor value since it is read-only' // eslint-disable-line max-len
+    EDITOR_READ_ONLY : 'Cannot change the CodeEditor value since it’s read only'
 };
 
 export default class CodeEditorDriver
@@ -20,13 +22,11 @@ export default class CodeEditorDriver
 
     blur()
     {
-        /* eslint-disable no-undef */
         if ( this.control.hasFocus() && Boolean( document ) &&
             Boolean( document.activeElement ) )
         {
             document.activeElement.blur();
         }
-        /* eslint-enable no-undef */
         return this;
     }
 
@@ -37,8 +37,14 @@ export default class CodeEditorDriver
             throw new Error( ERRORS.EDITOR_READ_ONLY );
         }
 
+        const onChange = this.wrapper.prop( 'onChange' );
+
         this.focus();
         this.control.setValue( value );
+        if ( onChange )
+        {
+            onChange( this.getInputValue() );
+        }
         this.blur();
         return this;
     }

--- a/src/CodeEditor/tests.jsx
+++ b/src/CodeEditor/tests.jsx
@@ -66,17 +66,31 @@ describe( 'CodeEditorDriver', () =>
     {
         it( 'should set the input value to "foo"', () =>
         {
-            const arg = 'foo';
-            driver.setInputValue( arg );
-            expect( CodeMirror.getValue() ).to.equal( arg );
+            driver.setInputValue( 'foo' );
+            expect( CodeMirror.getValue() ).to.equal( 'foo'  );
+        } );
+
+        it( 'should fire the onChange callback prop', () =>
+        {
+            const onChange = sinon.spy();
+            wrapper.setProps( { onChange } );
+            driver.setInputValue( 'foo' );
+            expect( onChange.calledOnce ).to.be.true;
+        } );
+
+        it( 'should call onChange with new value as argument', () =>
+        {
+            const onChange = sinon.spy();
+            wrapper.setProps( { onChange } );
+            driver.setInputValue( 'foo' );
+            expect( onChange.calledWith( 'foo' ) ).to.be.true;
         } );
 
         it( 'should throw the expected error when component isReadOnly', () =>
         {
             wrapper.setProps( { isReadOnly: true } );
-            const arg = 'foo';
-            expect( () => driver.setInputValue( arg ) ).to.throw(
-                'Cannot change the CodeEditor value since it is read-only' );
+            expect( () => driver.setInputValue( 'foo' ) ).to.throw(
+                'Cannot change the CodeEditor value since it’s read only' );
         } );
     } );
 
@@ -96,7 +110,7 @@ describe( 'CodeEditorDriver', () =>
                 isReadOnly : true
             } );
             expect( () => driver.clearInputValue() ).to.throw(
-                'Cannot change the CodeEditor value since it is read-only' );
+                'Cannot change the CodeEditor value since it’s read only' );
         } );
     } );
 


### PR DESCRIPTION
- Manually call the `onChange` callback when we set new value in the `setInputValue` driver method
- Added more tests for `setInputValue`
- Shortened `EDITOR_READ_ONY` message so it fits on one line 